### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,9 +34,9 @@ Here are some guidelines to help the review process go smoothly.
    features or make changes out of the scope of those requested by the reviewer
    (doing this just add delays as already reviewed code ends up having to be
    re-reviewed/it is hard to tell what is new etc!). Further, please do not
-   rebase your branch on master/force push/rewrite history, doing any of these
+   rebase your branch on main/force push/rewrite history, doing any of these
    causes the context of any comments made by reviewers to be lost. If
-   conflicts occur against master they should be resolved by merging master
+   conflicts occur against main they should be resolved by merging main
    into the branch used for making the pull request.
 
 Many thanks in advance for your cooperation!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ into three categories:
 
 ### Your first issue
 
-1. Read the project's [README.md](https://github.com/rapidsai/cuDataShader/blob/master/README.md)
+1. Read the project's [README.md](https://github.com/rapidsai/cuDataShader/blob/main/README.md)
     to learn how to setup the development environment
 2. Find an issue to work on. The best way is to look for the [good first issue](https://github.com/rapidsai/cuDataShader/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
     or [help wanted](https://github.com/rapidsai/cuDataShader/issues?q=is%3Aissue+is%3Aopen+label%3A%22help+wanted%22) labels

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 The [RAPIDS](https://rapids.ai) cuDataShader - GPU Accelerated
 
-![cuDataShaderGeo](https://github.com/rapidsai/cuDataShader/blob/master/files/cuDataShader.png)
+![cuDataShaderGeo](https://github.com/rapidsai/cuDataShader/blob/main/files/cuDataShader.png)
 
 cuDataShader is a port of PyViz's [Datashader](http://datashader.org/) using GPU CUDA technology to enable up to 50x acceleration in visualization render times. Started as an intern project, cuDatashader is still in its infancy and is not feature complete with Datashader. Plans are in the works to actively work with the PyViz group to implement or extend Datashader with further GPU acceleration. cuDataShader is a chart component of the RAPIDS [cuXfilter](https://github.com/rapidsai/cuxfilter) library.
 
@@ -45,6 +45,6 @@ $ python3 setup.py install # For Python3
 
 ## Contributing Guide
 
-Review the [CONTRIBUTING.md](https://github.com/rapidsai/cuDataShader/blob/master/CONTRIBUTING.md) file for information on how to contribute code and issues to the project.
+Review the [CONTRIBUTING.md](https://github.com/rapidsai/cuDataShader/blob/main/CONTRIBUTING.md) file for information on how to contribute code and issues to the project.
 
 


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.